### PR TITLE
[ISSUE #7]not send nearby if local mq less than threshold

### DIFF
--- a/defibus-client/src/main/java/cn/webank/defibus/client/common/DeFiBusClientConfig.java
+++ b/defibus-client/src/main/java/cn/webank/defibus/client/common/DeFiBusClientConfig.java
@@ -58,6 +58,8 @@ public class DeFiBusClientConfig {
     private long pullTimeDelayMillsWhenFlowControl = 50;
     private long pullTimeDelayMillsWhenSuspend = 500;
 
+    private int minMqNumWhenSendLocal = 1;
+
     public String getProducerGroup() {
         return producerGroup;
     }
@@ -270,6 +272,14 @@ public class DeFiBusClientConfig {
         this.pullTimeDelayMillsWhenSuspend = pullTimeDelayMillsWhenSuspend;
     }
 
+    public int getMinMqNumWhenSendLocal() {
+        return minMqNumWhenSendLocal;
+    }
+
+    public void setMinMqNumWhenSendLocal(int minMqNumWhenSendLocal) {
+        this.minMqNumWhenSendLocal = minMqNumWhenSendLocal;
+    }
+
     @Override public String toString() {
         return "DeFiBusClientConfig{" +
             "producerGroup='" + producerGroup + '\'' +
@@ -299,6 +309,7 @@ public class DeFiBusClientConfig {
             ", pullTimeDelayMillsWhenExcept=" + pullTimeDelayMillsWhenExcept +
             ", pullTimeDelayMillsWhenFlowControl=" + pullTimeDelayMillsWhenFlowControl +
             ", pullTimeDelayMillsWhenSuspend=" + pullTimeDelayMillsWhenSuspend +
+            ", minMqNumWhenSendLocal=" + minMqNumWhenSendLocal +
             '}';
     }
 }

--- a/defibus-client/src/main/java/cn/webank/defibus/client/impl/producer/DeFiBusProducerImpl.java
+++ b/defibus-client/src/main/java/cn/webank/defibus/client/impl/producer/DeFiBusProducerImpl.java
@@ -70,7 +70,8 @@ public class DeFiBusProducerImpl {
     public DeFiBusProducerImpl(DeFiBusProducer deFiBusProducer, DeFiBusClientConfig deFiBusClientConfig,
         DeFiBusClientInstance deFiBusClientInstance) {
         this.deFiBusProducer = deFiBusProducer;
-        this.messageQueueSelector = new HealthyMessageQueueSelector(new MessageQueueHealthManager(deFiBusClientConfig.getQueueIsolateTimeMillis()));
+        this.messageQueueSelector = new HealthyMessageQueueSelector(new MessageQueueHealthManager(deFiBusClientConfig.getQueueIsolateTimeMillis()),
+                deFiBusClientConfig.getMinMqNumWhenSendLocal());
 
         executorService = deFiBusClientInstance.getExecutorService();
         scheduledExecutorService = deFiBusClientInstance.getScheduledExecutorService();

--- a/defibus-client/src/main/java/cn/webank/defibus/client/impl/producer/HealthyMessageQueueSelector.java
+++ b/defibus-client/src/main/java/cn/webank/defibus/client/impl/producer/HealthyMessageQueueSelector.java
@@ -39,11 +39,13 @@ public class HealthyMessageQueueSelector implements MessageQueueSelector {
     private final AtomicInteger sendWhichLocalQueue = new AtomicInteger(0);
     private final AtomicInteger sendWhichRemoteQueue = new AtomicInteger(0);
     private final MessageQueueHealthManager messageQueueHealthManager;
+    private int minMqCountWhenSendLocal = 1;
     private Map<String, Boolean> sendNearbyMapping = new HashMap<>();
     private Set<String> localBrokers = new HashSet<String>();
 
-    public HealthyMessageQueueSelector(MessageQueueHealthManager messageQueueHealthManager) {
+    public HealthyMessageQueueSelector(MessageQueueHealthManager messageQueueHealthManager, int minMqCountWhenSendLocal) {
         this.messageQueueHealthManager = messageQueueHealthManager;
+        this.minMqCountWhenSendLocal = minMqCountWhenSendLocal;
     }
 
     @Override
@@ -61,7 +63,14 @@ public class HealthyMessageQueueSelector implements MessageQueueSelector {
         if (pub2local) {
             List<MessageQueue> localMQs = new ArrayList<>();
             List<MessageQueue> remoteMqs = new ArrayList<>();
-            separateLocalAndRemoteMQs(mqs, localBrokers, localMQs, remoteMqs);
+            HashMap<String, Integer> localBrokerMQCount = separateLocalAndRemoteMQs(mqs, localBrokers, localMQs, remoteMqs);
+
+            for (String brokerName : localBrokerMQCount.keySet()) {
+                //if MQ num less than threshold, send msg to all broker
+                if (localBrokerMQCount.get(brokerName) <= minMqCountWhenSendLocal) {
+                    localMQs.addAll(remoteMqs);
+                }
+            }
 
             //try select a mq from local idc first
             MessageQueue candidate = selectMessageQueue(localMQs, sendWhichLocalQueue, lastOne, msg);
@@ -154,20 +163,26 @@ public class HealthyMessageQueueSelector implements MessageQueueSelector {
         return result;
     }
 
-    private void separateLocalAndRemoteMQs(List<MessageQueue> mqs, Set<String> localBrokers,
+    private HashMap<String, Integer> separateLocalAndRemoteMQs(List<MessageQueue> mqs, Set<String> localBrokers,
         List<MessageQueue> localMQs, List<MessageQueue> remoteMQs) {
         if (localMQs == null)
             localMQs = new ArrayList<>();
         if (remoteMQs == null)
             remoteMQs = new ArrayList<>();
-
+        HashMap<String, Integer> brokerMQCount = new HashMap<>();
         for (MessageQueue mq : mqs) {
             if (localBrokers.contains(mq.getBrokerName())) {
                 localMQs.add(mq);
+                Integer count = brokerMQCount.get(mq.getBrokerName());
+                if (count == null) {
+                    count = 0;
+                }
+                brokerMQCount.put(mq.getBrokerName(), count+1);
             } else {
                 remoteMQs.add(mq);
             }
         }
+        return brokerMQCount;
     }
 
     public MessageQueueHealthManager getMessageQueueHealthManager() {

--- a/defibus-client/src/test/java/cn/webank/defibus/client/producer/HealthyMessageQueueSelectorTest.java
+++ b/defibus-client/src/test/java/cn/webank/defibus/client/producer/HealthyMessageQueueSelectorTest.java
@@ -45,7 +45,7 @@ public class HealthyMessageQueueSelectorTest {
 //        PowerMockito.when(producerImplMock.getLocalBrokers()).thenReturn(locBrokers);
 
         MessageQueueHealthManager manager = new MessageQueueHealthManager(60 * 1000);
-        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager);
+        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager, 1);
         selector.setLocalBrokers(locBrokers);
 
         List<MessageQueue> mqs = new ArrayList<>();
@@ -65,7 +65,7 @@ public class HealthyMessageQueueSelectorTest {
         locBrokers.add("localIDC");
 
         MessageQueueHealthManager manager = new MessageQueueHealthManager(60 * 1000);
-        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager);
+        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager, 1);
         selector.setLocalBrokers(locBrokers);
 
         List<MessageQueue> mqs = new ArrayList<>();
@@ -92,7 +92,7 @@ public class HealthyMessageQueueSelectorTest {
         locBrokers.add("localIDC");
 
         MessageQueueHealthManager manager = new MessageQueueHealthManager(60 * 1000);
-        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager);
+        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager, 1);
         selector.setLocalBrokers(locBrokers);
 
         List<MessageQueue> mqs = new ArrayList<>();
@@ -122,7 +122,7 @@ public class HealthyMessageQueueSelectorTest {
         localBrokers.add(localBrokerName);
 
         MessageQueueHealthManager manager = new MessageQueueHealthManager(60 * 1000);
-        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager);
+        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager, 1);
         selector.setLocalBrokers(localBrokers);
 
         //construct mq data
@@ -193,7 +193,7 @@ public class HealthyMessageQueueSelectorTest {
         }
 
         MessageQueueHealthManager manager = new MessageQueueHealthManager(60 * 1000);
-        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager);
+        HealthyMessageQueueSelector selector = new HealthyMessageQueueSelector(manager, 1);
         selector.setLocalBrokers(localBrokers);
 
         //construct mq data


### PR DESCRIPTION
this pr works for [issue #7  ](https://github.com/WeBankFinTech/DeFiBus/issues/7)

Calculating MessageQueue num of each broker, if the num of MQ in a broker is not greatter than theashold, it will send msg to all brokers not only brokers in the same idc.
