### PR TITLE
fix potential overflow and limit upper bound

### DIFF
--- a/defibus-broker/src/main/java/cn/webank/defibus/broker/client/AdjustQueueNumStrategy.java
+++ b/defibus-broker/src/main/java/cn/webank/defibus/broker/client/AdjustQueueNumStrategy.java
@@ -84,7 +84,8 @@ public class AdjustQueueNumStrategy {
 
             case DECREASE_QUEUE_NUM:
                 adjustWriteQueueNumByConsumerCount(topic, 0, scaleType);
-                long delayTimeMillis = deFiBrokerController.getDeFiBusBrokerConfig().getScaleQueueSizeDelayTimeMinute() * 60 * 1000;
+                long delayTimeMinutes = Math.min(deFiBrokerController.getDeFiBusBrokerConfig().getScaleQueueSizeDelayTimeMinute(), 10);
+                long delayTimeMillis = delayTimeMinutes * 60 * 1000;
                 adjustReadQueueNumByConsumerCount(topic, delayTimeMillis, scaleType);
                 break;
         }


### PR DESCRIPTION
it may cause overflow when calculate with int and assigns to long.
assign int value to a long variable and then do calculating to avoid overflow.